### PR TITLE
Add big and box styles for buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ import { ElButton, ElTooltip } from 'vue-el-element'
   :secondary="Boolean"
   :danger="Boolean"
   :link="Boolean"
+  :big="Boolean"
+  :box="Boolean"
   :margin-right="Boolean"
   :margin-top="Boolean"
   :tooltip="String"

--- a/src/components/elements/ElButton.vue
+++ b/src/components/elements/ElButton.vue
@@ -12,11 +12,13 @@
     'el-button--secondary': secondary && !danger && !disabled,
     'el-button--secondary--danger': danger && secondary && !disabled,
     'el-button--link': link,
+    'el-button--big': big,
+    'el-button--box': box,
     'el-align--right': right,
     'el-margin--right': marginRight,
     'el-margin--top': marginTop,
     'el-margin--left': marginLeft,
-    'el-margin--bottom': marginBottom
+    'el-margin--bottom': marginBottom,
   }"
   >
   <el-tooltip
@@ -49,8 +51,9 @@ export default {
     marginRight: Boolean,
     marginTop: Boolean,
     marginBottom: Boolean,
-    marginLeft: Boolean
-
+    marginLeft: Boolean,
+    big: Boolean,
+    box: Boolean
   },
   methods: {
     next () {
@@ -159,6 +162,15 @@ export default {
         color: @color-button-link;
         text-decoration: underline;
       }
+    }
+
+    &--big {
+      font-size: 22px;
+    }
+
+    &--box {
+      height: 50px;
+      border-radius: 5px;
     }
   }
 </style>

--- a/src/docs/ElButtonDocs.vue
+++ b/src/docs/ElButtonDocs.vue
@@ -54,6 +54,21 @@
       >
       Link
     </el-button>
+    <el-button
+      big
+      margin-right
+      margin-top
+      >
+      Big button
+    </el-button>
+    <el-button
+      box
+      danger
+      margin-right
+      margin-top
+      >
+      Box button
+    </el-button>
   </el-inline>
 
   <el-delimiter />


### PR DESCRIPTION
This PR adds a `big` and `box` prop for the button component.

`big` will make the text larger, whereas `box` will add padding to make button higher.