### PR TITLE
Pass native event in button click emit

### DIFF
--- a/src/components/elements/ElButton.vue
+++ b/src/components/elements/ElButton.vue
@@ -56,10 +56,10 @@ export default {
     }
   },
   methods: {
-    next () {
+    next (e) {
       if (this.disabled === true) return
 
-      this.$emit('click')
+      this.$emit('click', e)
 
       setTimeout(() => {
         if (this.$el && this.$el.blur) {


### PR DESCRIPTION
Currently, using the Vue-shorthand `@click.stop` or `@click.prevent` on an `ElButton` element throws an error since the native event is not passed in the `$emit('click')`-call

This PR solves this for click-events on `ElButton` by simply passing the native event as the first (and only) argument when emitting the click event. This allows the user to use this event and call native functions like `.preventDefault()`, `.stopPropagation()`, and others, or use the Vue shorthands.

There may be other cases/components that could use the same update.